### PR TITLE
Corrección para multiplicar el IVA

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ desde el panel de administración.
 de clientes.
 Reportes de historial de facturas y pedidos pendientes de facturar.
 
+## Fix 20/04/21
+
+- Calculo correcto del IVA
+
 ## Fix 14/06/20
 
 - Nueva Opción de elegir USO CFDI en tienda antes de realizar factura

--- a/assets/facturacom.js
+++ b/assets/facturacom.js
@@ -450,7 +450,7 @@ jQuery(document).ready( function($) {
             calculate_tax = 0.16;
             pre_unit_price = Number(products[key]['total']/products[key]['quantity']);
             tax = Number(pre_unit_price * calculate_tax);
-            taxes=taxes+tax;
+            taxes = taxes + (tax * products[key]['quantity']);
             unit_price = Number(pre_unit_price);
           }
           else{
@@ -463,14 +463,14 @@ jQuery(document).ready( function($) {
           calculate_tax = 0.16;
           pre_unit_price = Number(products[key]['total']/products[key]['quantity']);
           tax = Number(pre_unit_price * calculate_tax);
-          taxes=taxes+tax;
+          taxes = taxes + (tax * products[key]['quantity']);
           unit_price = Number(pre_unit_price);
         }
         else{
           calculate_tax = 0.16;
           pre_unit_price = Number(products[key]['total']/products[key]['quantity']);
           tax = Number(pre_unit_price * calculate_tax);
-          taxes=taxes+tax;
+          taxes = taxes + (tax * products[key]['quantity']);
           unit_price = Number(pre_unit_price);
         }
       }

--- a/facturacom.php
+++ b/facturacom.php
@@ -3,7 +3,7 @@
 * Plugin name: Factura punto com para woocommerce
 * Plugin URI: http://factura.com
 * Description: Conecta tu tienda de woocommerce para que tus clientes puedan facturar todos los pedidos.
-* Version: 1.6.4
+* Version: 1.6.5
 * Author: Factura.com
 */
 


### PR DESCRIPTION
Cuando se trata de calcular el IVA total del pedido, solo se suman los ivas de los productos una única vez, aunque se compren mas de una unidad.

Para replicar el error se debe de seleccionar **No** en "Mis productos incluyen IVA".


