### PR TITLE
Se realizó la validación si el pedido no existe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ desde el panel de administración.
 de clientes.
 Reportes de historial de facturas y pedidos pendientes de facturar.
 
+## Fix 27/05/21
+
+- Validación cuando el pedido no existe
+
 ## Fix 20/04/21
 
 - Calculo correcto del IVA

--- a/facturacom.php
+++ b/facturacom.php
@@ -3,7 +3,7 @@
 * Plugin name: Factura punto com para woocommerce
 * Plugin URI: http://factura.com
 * Description: Conecta tu tienda de woocommerce para que tus clientes puedan facturar todos los pedidos.
-* Version: 1.6.5
+* Version: 1.6.6
 * Author: Factura.com
 */
 

--- a/inc/commerce-helper.php
+++ b/inc/commerce-helper.php
@@ -6,6 +6,9 @@ class CommerceHelper{
         // $order = new WC_Order($orderId);
         $order = wc_get_order($orderId);
         // var_dump($order->get_items());
+        if(!$order){
+            return array('Error' => 'El pedido no existe');
+        }
         $order_post = get_post( $orderId );
         $configEntity = FacturaConfig::configEntity();
         $order_data = array(

--- a/inc/factura-wrapper.php
+++ b/inc/factura-wrapper.php
@@ -521,6 +521,9 @@ class FacturaWrapper{
 
       $order = CommerceHelper::getOrderById($orderId);
 
+      if(gettype($order) != 'object'){
+        return array('Error' => 'El pedido no existe');
+      }
       return $order;
     }
 


### PR DESCRIPTION
Si en el formulario escribes un numero de pedido que no existe, la petición manda un error 500 y se queda cargando el formulario.