### PR TITLE
Cálculo más preciso en los conceptos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ desde el panel de administración.
 de clientes.
 Reportes de historial de facturas y pedidos pendientes de facturar.
 
+## Feature 05/11/2022
+
+- Ahora se toman en cuenta los decimales configurados en woocommerce para el cálculo de los conceptos.
+
 ## Feature 06/04/2022
 
 - Se sustituye la versión de timbrado de cfdi 3.3 por 4.0, por lo que los campos necesarios se modifican.

--- a/assets/facturacom.js
+++ b/assets/facturacom.js
@@ -426,6 +426,8 @@ jQuery(document).ready( function($) {
     var discount = Number(order_data.order_discount);
     var onlyShip = false;
     var prices_with_tax = order_data.price_with_tax;
+    var decimals = order_data.decimals;
+
     // var discount = Number(order_data.total_discount);
 
     var r = new Array(), j = -1;
@@ -567,9 +569,9 @@ jQuery(document).ready( function($) {
       r[++j] = '</td><td>';
       r[++j] = products[key]['quantity'];
       r[++j] = '</td><td>$';
-      r[++j] = (unit_price).formatMoney(2, '.', ',');
+      r[++j] = (unit_price).formatMoney(decimals, '.', ',');
       r[++j] = '</td><td>$';
-      r[++j] = (unit_subtotal).formatMoney(2, '.', ',');
+      r[++j] = (unit_subtotal).formatMoney(decimals, '.', ',');
       r[++j] = '</td></tr>';
 
       subtotal = Number(subtotal) + Number(unit_subtotal);
@@ -583,7 +585,7 @@ jQuery(document).ready( function($) {
       unit_price = 0;
     }
     $('#datails-body').html(r.join(''));
-    console.log(taxes);
+    // console.log(taxes);
     var grand_total = Number(order_data.total);
     // if(tax == 0){
     //     var total_iva = grand_total;

--- a/facturacom.php
+++ b/facturacom.php
@@ -3,7 +3,7 @@
 * Plugin name: Factura punto com para woocommerce
 * Plugin URI: http://factura.com
 * Description: Conecta tu tienda de woocommerce para que tus clientes puedan facturar todos los pedidos.
-* Version: 1.7.0
+* Version: 1.8.0
 * Author: Factura.com
 */
 

--- a/inc/commerce-helper.php
+++ b/inc/commerce-helper.php
@@ -11,7 +11,19 @@ class CommerceHelper{
         }
         $order_post = get_post( $orderId );
         $configEntity = FacturaConfig::configEntity();
+
+        $decimals = get_option('woocommerce_price_num_decimals');
+
+        if(in_array($decimals, ['1','2','3','4','5','6'])){
+          $decimals = intval($decimals);
+        } else if ($decimals > 6){
+          $decimals = 6;
+        } else {
+          $decimals = 2;
+        }
+        
         $order_data = array(
+          'decimals'                  => $decimals,
           'price_with_tax'            => $configEntity['sitax'],
           'id'                        => $order->id,
           'order_number'              => $order->get_order_number(),
@@ -85,14 +97,14 @@ class CommerceHelper{
           // var_dump($F_ClaveProdServ, $F_Unidad, $F_ClaveUnidad);
           $order_data['line_items'][] = array(
             'id'         => $item_id,
-            'subtotal'   => wc_format_decimal( $order->get_line_subtotal( $item ), 2 ),
-            'total'      => wc_format_decimal( $order->get_line_total( $item ), 2 ),
-            'total_tax'  => wc_format_decimal( $order->get_item_tax( $item ), 2 ),
-            'price'      => wc_format_decimal( $order->get_item_total( $item ), 2 ) + wc_format_decimal( $order->get_item_tax( $item ), 2 ),
+            'subtotal'   => wc_format_decimal( $order->get_line_subtotal( $item ), $decimals),
+            'total'      => wc_format_decimal( $order->get_line_total( $item ), $decimals),
+            'total_tax'  => wc_format_decimal( $order->get_item_tax( $item ), $decimals),
+            'price'      => wc_format_decimal( $order->get_item_total( $item ), $decimals ) + wc_format_decimal( $order->get_item_tax( $item ), $decimals ),
             'meta'       => array(
-                'item_total' => wc_format_decimal( $order->get_item_total( $item ), 2 ),
-                'line_tax'   => wc_format_decimal( $order->get_line_tax( $item ), 2 ),
-                'item_tax'   => wc_format_decimal( $order->get_item_tax( $item ), 2 ),
+              'item_total' => wc_format_decimal( $order->get_item_total( $item ), $decimals ),
+              'line_tax'   => wc_format_decimal( $order->get_line_tax( $item ), $decimals ),
+              'item_tax'   => wc_format_decimal( $order->get_item_tax( $item ), $decimals ),
             ),
             //'quantity'   => (int) $item['qty'], Problemas con cantidades decimales (a granel, ejemplo: 0.25)
             'quantity'   => $item['qty'],
@@ -117,10 +129,10 @@ class CommerceHelper{
             if($shipping_item['method_id'] != 'free_shipping'){
                 $order_data['line_items'][] = array(
                     'id'         => $shipping_key,
-                    'subtotal'   => wc_format_decimal($shipping_item['cost'], 2),
-                    'total'      => wc_format_decimal($shipping_item['cost'], 2),
-                    'total_tax'  => round($order->order_shipping_tax, 2),
-                    'price'      => wc_format_decimal($shipping_item['cost'], 2) + round($order->order_shipping_tax, 2),
+                    'subtotal'   => wc_format_decimal($shipping_item['cost'], $decimals),
+                    'total'      => wc_format_decimal($shipping_item['cost'], $decimals),
+                    'total_tax'  => round($order->order_shipping_tax, $decimals),
+                    'price'      => wc_format_decimal($shipping_item['cost'], $decimals) + round($order->order_shipping_tax, $decimals),
                     'quantity'   => 1,
                     'tax_class'  => null,
                     'name'       => $shipping_item['name'],


### PR DESCRIPTION
Se ha tomado en cuenta la cantidad de decimales configurados en la sección de ajustes de woocommerce para obtener la cantidad de decimales que toma en cuenta para el cálculo de los precios en los conceptos.